### PR TITLE
fix for PARSE_ERROR if there is a colon in the uri

### DIFF
--- a/lib/http.h
+++ b/lib/http.h
@@ -17,6 +17,7 @@ error_code http_sc_connect (RIP_MANAGER_INFO* rmi,
 			    const char *proxyurl, 
 			    SR_HTTP_HEADER *info, char *useragent, 
 			    char *if_name);
+error_code http_parse_url(const char *url, URLINFO *urlinfo);
 
 
 #endif //__HTTP_H__


### PR DESCRIPTION
My webradio has a quite long uri which contains colons, e.g.
"http://host.com:123/mypath?foo=abc:def" 
